### PR TITLE
Add odom controller and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# ROS ArUco Robot Project
+
+This workspace contains a simple set of Python nodes to calibrate a camera, detect an ArUco marker and publish its pose, and drive a robot using odometry feedback.
+
+## Nodes
+
+### `camera_intrinsics_node.py`
+Calibrates the camera using a chessboard pattern. After capturing at least three images press `q` to finish and the node will continuously publish the resulting `sensor_msgs/CameraInfo` on `/camera/camera_info`.
+
+### `camera_node.py`
+Detects an ArUco ID 0 marker from the camera feed, overlays the position on the image, and publishes the marker trajectory as a `nav_msgs/Path` on `/trajectory`. The raw annotated frames are published on `/camera/image_raw`.
+
+### `crtmovement.py`
+Basic controller that subscribes to `/trajectory` and drives the robot forward or backward on the x‐axis depending on the marker’s y position relative to the camera.
+
+### `odom_control_movement.py`
+New controller that uses odometry feedback. It subscribes to `/trajectory` for the target marker distance and to `/odom` to track robot motion. The robot moves forward or backward until the travelled distance matches the detected marker distance.
+
+## Usage
+1. Source your workspace and make sure the robot is running.
+2. Calibrate the camera:
+   ```
+   rosrun QRfollowing camera_intrinsics_node.py
+   ```
+3. In a new terminal, start the marker detection:
+   ```
+   rosrun QRfollowing camera_node.py
+   ```
+4. To drive using odometry feedback run:
+   ```
+   rosrun QRfollowing odom_control_movement.py
+   ```
+
+Adjust parameters such as `~kp`, `~tolerance` and `~max_speed` with ROS parameters if needed.

--- a/src/QRfollowing/CMakeLists.txt
+++ b/src/QRfollowing/CMakeLists.txt
@@ -158,10 +158,13 @@ include_directories(
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-# catkin_install_python(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+catkin_install_python(PROGRAMS
+  scripts/camera_intrinsics_node.py
+  scripts/camera_node.py
+  scripts/crtmovement.py
+  scripts/odom_control_movement.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark executables for installation
 ## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html

--- a/src/QRfollowing/package.xml
+++ b/src/QRfollowing/package.xml
@@ -51,10 +51,22 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>nav_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>cv_bridge</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/QRfollowing/scripts/odom_control_movement.py
+++ b/src/QRfollowing/scripts/odom_control_movement.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import rospy
+from nav_msgs.msg import Odometry, Path
+from geometry_msgs.msg import Twist
+
+class OdomControlNode(object):
+    """Drive the robot using odometry until it reaches the detected marker."""
+    def __init__(self):
+        rospy.init_node('odom_control_movement', anonymous=True)
+
+        self.path_sub = rospy.Subscriber('/trajectory', Path, self.path_cb)
+        self.odom_sub = rospy.Subscriber('/odom', Odometry, self.odom_cb)
+        self.cmd_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
+
+        self.target_dist = None
+        self.start_x = None
+        self.current_x = None
+
+        self.kp = rospy.get_param('~kp', 0.5)
+        self.tolerance = rospy.get_param('~tolerance', 0.05)
+        self.max_speed = rospy.get_param('~max_speed', 0.2)
+
+    def path_cb(self, msg):
+        if msg.poses:
+            self.target_dist = msg.poses[-1].pose.position.x
+            self.start_x = None
+            rospy.loginfo('New target distance: %.2f m', self.target_dist)
+
+    def odom_cb(self, msg):
+        self.current_x = msg.pose.pose.position.x
+
+    def run(self):
+        rate = rospy.Rate(10)
+        while not rospy.is_shutdown():
+            twist = Twist()
+            if self.target_dist is not None and self.current_x is not None:
+                if self.start_x is None:
+                    self.start_x = self.current_x
+                travelled = self.current_x - self.start_x
+                error = self.target_dist - travelled
+                if abs(error) > self.tolerance:
+                    speed = max(-self.max_speed, min(self.max_speed, self.kp * error))
+                    twist.linear.x = speed
+                else:
+                    twist.linear.x = 0.0
+                    self.target_dist = None
+                    rospy.loginfo('Target reached within tolerance')
+            else:
+                rospy.loginfo_throttle(5, '[odom_control_movement] Waiting for trajectory and odom...')
+
+            self.cmd_pub.publish(twist)
+            rate.sleep()
+
+if __name__ == '__main__':
+    node = OdomControlNode()
+    try:
+        node.run()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
## Summary
- add a README describing the nodes and how to run them
- create `odom_control_movement.py` for odometry-based driving
- install python scripts via CMake
- declare dependencies for sensor, nav and geometry messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffdd98494832ab5e4b78198b1ffa2